### PR TITLE
Clean up identifiers

### DIFF
--- a/eu_dgc_v1_schema.yaml
+++ b/eu_dgc_v1_schema.yaml
@@ -65,26 +65,21 @@ properties:
           required:
             - t
             - i
+            - c
           properties:
             t:
               title: Identifier type
               description: The type of identifier (viz. VS-2021-04-08)
                 PP = Passport Number
-                NN = National Person Identifier
+                NN = National Person Identifier (country specified in the 'c' parameter)
                 CZ = Citizenship Card Number
-                HC = Health Card number
-                NI = National Unique Individual Identifier
-                MB = Member Number
-                NH = National Helth Plan Identifier
+                HC = Health Card Number
               type: string
               enum:
                 - PP
                 - NN
                 - CZ
                 - HC
-                - NI
-                - MB
-                - NH
               example: NN
             c:
               title: Country
@@ -92,7 +87,7 @@ properties:
               type: string
               example: SE
             i:
-              title: Identfier number or string
+              title: Identifier number or string
               type: string
               example: 121212-1212
       dob:


### PR DESCRIPTION

I propose to clean up the identifiers object. This can used to create a binding between the DGC and its rightful holder. Reading the value sets document from 2021-04-14 these are "Elements that might be relevant in the realm of Vaccination and testing data set but are not included in the DGC". 

(In fact, it is not part of the minimal data set, which means that it might have to be dropped entirely)

Further reading of the HL7 terminology reveals no actual difference between a "National Person Identifier" and "National unique individual identifier" (the latter seems to be related to US and HIPAA related transactions). So I propose to remove NI and require the country, to be able to form the national person identifier.

Also, National Health Plan Identifier and Member Number identifies insurance policies, which seems completely irrelevant in creating a binding between the person carrying a DSC and its rightful owner. 

For the Health Card Number I can conclude that the European health card does not carry any information which can be used to create the binding, but some states in the US and CA actually seems issue health cards with photo and handwritten signatures on them. So likely other countries do this as well, and maybe som MS do. For this reason I suggest to keep this one in.

I believe we should make 'c' mandatory for all types, to frame the scope of the identifier type.

We could consider adding DL (Drivers license number), it is likely more useful than Health Card Number. For example, someone resident in a MS but who is not a citizen, may not be able get a passport or a citizen card. But can in fact get a drivers license. But as it seems to have not been discussed, I'm reluctant to adding it now.

