### PR TITLE
Subject cleanup

### DIFF
--- a/eu_dgc_v1_schema.json
+++ b/eu_dgc_v1_schema.json
@@ -97,7 +97,7 @@
                 },
                 "dob": {
                     "title": "Date of birth",
-                    "description": "The date of birth for of the person addressed in the certificate",
+                    "description": "The date of birth of the person addressed in the certificate",
                     "type": "string",
                     "format": "date",
                     "example": "2012-12-12"

--- a/eu_dgc_v1_schema.json
+++ b/eu_dgc_v1_schema.json
@@ -27,8 +27,7 @@
             "type": "object",
             "required": [
                 "gn",
-                "dob",
-                "gen"
+                "dob"
             ],
             "properties": {
                 "gn": {
@@ -63,6 +62,7 @@
                         "type": "object",
                         "required": [
                             "t",
+                            "c",
                             "i"
                         ],
                         "properties": {
@@ -97,22 +97,10 @@
                 },
                 "dob": {
                     "title": "Date of birth",
-                    "description": "Mandatory if no Person identifier is provided",
+                    "description": "The date of birth for of the person addressed in the certificate",
                     "type": "string",
                     "format": "date",
                     "example": "2012-12-12"
-                },
-                "gen": {
-                    "title": "Administrative gender",
-                    "description": "Administrative gender (optional, viz. VS-2021-04-14)",
-                    "type": "string",
-                    "enum": [
-                        "male",
-                        "female",
-                        "other",
-                        "unknown"
-                    ],
-                    "example": "male"
                 }
             }
         },

--- a/eu_dgc_v1_schema.yaml
+++ b/eu_dgc_v1_schema.yaml
@@ -97,7 +97,7 @@ properties:
               example: 121212-1212
       dob:
         title: Date of birth
-        description: Mandatory if no Person identifier is provided
+        description: The date of birth for of the person addressed in the certificate
         type: string
         format: date
         example: "2012-12-12"

--- a/eu_dgc_v1_schema.yaml
+++ b/eu_dgc_v1_schema.yaml
@@ -64,6 +64,7 @@ properties:
           type: object
           required:
             - t
+            - c
             - i
           properties:
             t:

--- a/eu_dgc_v1_schema.yaml
+++ b/eu_dgc_v1_schema.yaml
@@ -98,7 +98,7 @@ properties:
               example: 121212-1212
       dob:
         title: Date of birth
-        description: The date of birth for of the person addressed in the certificate
+        description: The date of birth of the person addressed in the certificate
         type: string
         format: date
         example: "2012-12-12"

--- a/eu_dgc_v1_schema.yaml
+++ b/eu_dgc_v1_schema.yaml
@@ -102,16 +102,6 @@ properties:
         type: string
         format: date
         example: "2012-12-12"
-      gen:
-        title: Administrative gender
-        description: Administrative gender (optional, viz. VS-2021-04-14)
-        type: string
-        enum:
-          - male
-          - female
-          - other
-          - unknown
-        example: male
 
   vac:
     description: Vaccination/prophylaxis information

--- a/eu_dgc_v1_schema_draft_07.json
+++ b/eu_dgc_v1_schema_draft_07.json
@@ -25,8 +25,7 @@
             "type": "object",
             "required": [
                 "gn",
-                "dob",
-                "gen"
+                "dob"
             ],
             "properties": {
                 "gn": {
@@ -57,6 +56,7 @@
                         "type": "object",
                         "required": [
                             "t",
+                            "c",
                             "i"
                         ],
                         "properties": {
@@ -88,20 +88,9 @@
                 },
                 "dob": {
                     "title": "Date of birth",
-                    "description": "Mandatory if no Person identifier is provided",
+                    "description": "The date of birth for of the person addressed in the certificate",
                     "type": "string",
                     "format": "date"
-                },
-                "gen": {
-                    "title": "Administrative gender",
-                    "description": "Administrative gender (optional, viz. VS-2021-04-14)",
-                    "type": "string",
-                    "enum": [
-                        "male",
-                        "female",
-                        "other",
-                        "unknown"
-                    ]
                 }
             }
         },

--- a/eu_dgc_v1_schema_draft_07.json
+++ b/eu_dgc_v1_schema_draft_07.json
@@ -88,7 +88,7 @@
                 },
                 "dob": {
                     "title": "Date of birth",
-                    "description": "The date of birth for of the person addressed in the certificate",
+                    "description": "The date of birth of the person addressed in the certificate",
                     "type": "string",
                     "format": "date"
                 }


### PR DESCRIPTION
Clean up `sub` based on annex:

- `dob` is required
- `id` now includes required country of (id) issuer
- `gen` removed