### PR TITLE
Unique DGC identifier

### DIFF
--- a/eu_dgc_v1_schema.yaml
+++ b/eu_dgc_v1_schema.yaml
@@ -25,7 +25,7 @@ properties:
       country code of the issuing country followed by any number of characters 
       in the range [0-9A-Z].
     type: string
-    pattern: "[A-Z]{2}[A-Z0-9]+"
+    pattern: "[A-Z]{2}[A-Z0-9]+$"
     example: "SEW567YUT54"
   sub:
     description: Subject

--- a/eu_dgc_v1_schema.yaml
+++ b/eu_dgc_v1_schema.yaml
@@ -25,6 +25,7 @@ properties:
       country code of the issuing country followed by any number of characters 
       in the range [0-9A-Z].
     type: string
+    pattern: "[A-Z]{2}[A-Z0-9]+"
     example: "SEW567YUT54"
   sub:
     description: Subject

--- a/eu_dgc_v1_schema.yaml
+++ b/eu_dgc_v1_schema.yaml
@@ -19,11 +19,6 @@ properties:
     description: Version of the schema, according to Semantic versioning (ISO, https://semver.org/ version 2.0.0 or newer) (viz. guidelines)
     type: string
     example: "1.0.0"
-  dgcid:
-    title: Identifier
-    description: Unique identifier of the DGC (initially called UVCI (V for vaccination), later renamed to DGCI), format and composizion viz. guidelines
-    type: string
-    example: "01AT42196560275230427402470256520250042"
   sub:
     description: Subject
     type: object

--- a/eu_dgc_v1_schema.yaml
+++ b/eu_dgc_v1_schema.yaml
@@ -19,6 +19,13 @@ properties:
     description: Version of the schema, according to Semantic versioning (ISO, https://semver.org/ version 2.0.0 or newer) (viz. guidelines)
     type: string
     example: "1.0.0"
+  dgcid:
+    title: Digital Green Certificate Identifier
+    description: Unique identifier of the DGC. The ID must be prefixed with the 
+      country code of the issuing country followed by any number of characters 
+      in the range [0-9A-Z].
+    type: string
+    example: "SEW567YUT54"
   sub:
     description: Subject
     type: object

--- a/eu_dgc_v1_schema.yaml
+++ b/eu_dgc_v1_schema.yaml
@@ -25,7 +25,7 @@ properties:
       country code of the issuing country followed by any number of characters 
       in the range [0-9A-Z].
     type: string
-    pattern: "[A-Z]{2}[A-Z0-9]+$"
+    pattern: "^[A-Z]{2}[A-Z0-9]+$"
     example: "SEW567YUT54"
   sub:
     description: Subject


### PR DESCRIPTION
Colleagues, I propose to use the COSE signature as an opaque identifier of the DGC to fulfil the requirement of a unique certificate identifier per the proposed regulation (Annex, point 1(g)) rather than this DGCID.

The signature consists of 64 bytes which in practice is guaranteed to be universally unique. 

Adding another identifier is only increasing the size of the DGC and creates additional burdens, i believe?  